### PR TITLE
feat: Input 컴포넌트 구현

### DIFF
--- a/src/components/Input/Input.stories.tsx
+++ b/src/components/Input/Input.stories.tsx
@@ -1,0 +1,21 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+import Input from './Input';
+
+export default {
+  title: 'components/Input',
+  component: Input,
+} as ComponentMeta<typeof Input>;
+
+const Template: ComponentStory<typeof Input> = ({ ...args }) => {
+  return <Input {...args} />;
+};
+
+export const Default = Template.bind({});
+Default.args = {};
+
+export const Error = Template.bind({});
+Error.args = {
+  value: '닉네임',
+  status: 'error',
+};

--- a/src/components/Input/Input.styles.tsx
+++ b/src/components/Input/Input.styles.tsx
@@ -1,0 +1,46 @@
+import { pxToRem } from '@/utils';
+import styled, { css } from 'styled-components';
+
+export const Container = styled.div`
+  position: relative;
+  width: 100%;
+`;
+
+export const Input = styled.input<{ status: 'default' | 'error' }>`
+  width: 100%;
+  margin: ${pxToRem(8)} 0;
+  padding: ${pxToRem(10)} ${pxToRem(16)};
+  border-radius: ${pxToRem(5)};
+
+  ${({ status }) =>
+    status === 'default' &&
+    css`
+      border: 1px solid ${({ theme }) => theme.colors.gray};
+    `};
+
+  ${({ status }) =>
+    status === 'error' &&
+    css`
+      border: 1px solid ${({ theme }) => theme.colors.red};
+    `};
+`;
+
+export const StatusMessage = styled.p<{ status: 'default' | 'error' }>`
+  position: absolute;
+  left: ${pxToRem(4)};
+  bottom: ${pxToRem(-16)};
+  margin: 0;
+  font-size: ${({ theme }) => theme.fontSizes.sm};
+
+  ${({ status }) =>
+    status === 'default' &&
+    css`
+      color: ${({ theme }) => theme.colors.black};
+    `};
+
+  ${({ status }) =>
+    status === 'error' &&
+    css`
+      color: ${({ theme }) => theme.colors.red};
+    `};
+`;

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -1,0 +1,40 @@
+import { ComponentPropsWithoutRef, forwardRef } from 'react';
+import * as S from './Input.styles';
+
+export interface InputProps extends ComponentPropsWithoutRef<'input'> {
+  id?: string;
+  value: string;
+  status?: 'default' | 'error';
+  onChange: React.ChangeEventHandler<HTMLInputElement>;
+  onFocus?: React.FocusEventHandler<HTMLInputElement>;
+  onBlur?: React.FocusEventHandler<HTMLInputElement>;
+}
+
+const Input = forwardRef<HTMLInputElement, InputProps>(
+  ({ id, value, status = 'default', onChange, ...rest }, ref) => {
+    return (
+      <S.Container>
+        <S.Input
+          ref={ref}
+          id={id}
+          type="text"
+          value={value}
+          status={status}
+          required
+          placeholder="닉네임을 입력해주세요."
+          onChange={onChange}
+          {...rest}
+        />
+        {status === 'error' && (
+          <S.StatusMessage status={status}>
+            이미 존재하는 닉네임입니다.
+          </S.StatusMessage>
+        )}
+      </S.Container>
+    );
+  }
+);
+
+Input.displayName = 'Input';
+
+export default Input;

--- a/src/components/Input/index.ts
+++ b/src/components/Input/index.ts
@@ -1,0 +1,1 @@
+export { default as Input } from './Input';

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -2,11 +2,13 @@ import { DefaultTheme } from 'styled-components';
 import { pxToRem, createBreakPoint } from '@/utils';
 
 export const colors = {
-  primary_bright: '#efeefe',
-  primary_light: '#d0ccfc',
+  primary_bright: '#EFEEFE',
+  primary_light: '#D0CCFC',
   primary: '#6558F5',
-  primary_dark: '#5a4fdc',
-  primary_darkest: '#5046c4',
+  primary_dark: '#5A4FDC',
+  primary_darkest: '#5046C4',
+  red: '#DC3544',
+  gray: '#9C9C9C',
   black: '#444444',
   white: '#FFFFFF',
 };


### PR DESCRIPTION
## 설명

폼에 사용할 닉네임을 입력할 수 있는 입력 필드를 구현했습니다. 

## 변경 사항

- theme에 빨강과 회색 추가
- 닉네임을 입력할 수 있는 Input 컴포넌트 구현
- status를 통해 유효한 닉네임인지의 상태를 나타낼 수 있도록 구현
- 추후에 db에 존재하는 닉네임인지 확인할 로직 필요
- 추가적으로 필요하다면 validation 로직 구현 필요

## 스크린샷

<img width="578" alt="스크린샷 2023-03-21 오전 4 06 18" src="https://user-images.githubusercontent.com/68905615/226441776-cc6862fc-7f99-4996-b9e1-24b3a7bcfb49.png">

<img width="578" alt="스크린샷 2023-03-21 오전 4 06 25" src="https://user-images.githubusercontent.com/68905615/226441794-3a51780b-76e7-469a-8af9-2fef47f78bd6.png">