### PR TITLE
feat: Video 페이지 구현

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,6 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/src/components/VideoPlayer/VideoPlayer.styles.tsx
+++ b/src/components/VideoPlayer/VideoPlayer.styles.tsx
@@ -3,5 +3,5 @@ import styled from 'styled-components';
 export const Container = styled.div<{ width: string | number }>`
   position: relative;
   width: ${({ width }) => width};
-  aspect-ratio: 16 / 9;
+  height: 100%;
 `;

--- a/src/components/VideoPlayer/VideoPlayer.tsx
+++ b/src/components/VideoPlayer/VideoPlayer.tsx
@@ -6,11 +6,10 @@ interface VideoPlayerProps {
   url: string;
   controls?: boolean;
   width?: string;
-  onStart: () => void;
-  onPlay: () => void;
-  onStop: () => void;
-  onPause: () => void;
-  onEnded: () => void;
+  onStart?: () => void;
+  onPlay?: () => void;
+  onPause?: () => void;
+  onEnded?: () => void;
 }
 
 const VideoPlayer = ({
@@ -20,7 +19,6 @@ const VideoPlayer = ({
   onStart,
   onPlay,
   onPause,
-  onStop,
   onEnded,
 }: VideoPlayerProps) => {
   return (
@@ -30,10 +28,10 @@ const VideoPlayer = ({
         controls={controls}
         width="100%"
         height="100%"
+        playing
         onStart={onStart}
         onPlay={onPlay}
         onPause={onPause}
-        onStop={onStop}
         onEnded={onEnded}
       />
     </S.Container>

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -6,3 +6,4 @@ export {
   FIELDSETS,
 } from './form';
 export { KAKAO } from './kakao';
+export { VIDEOS } from './video';

--- a/src/constants/video.ts
+++ b/src/constants/video.ts
@@ -1,0 +1,67 @@
+import { Preference } from '@/types';
+
+export type VideoType = Preference | 'NEW';
+
+export interface Video {
+  id: number;
+  url: string;
+  type: VideoType;
+}
+
+export const VIDEOS: Video[] = [
+  {
+    id: 1,
+    url: 'https://www.youtube.com/shorts/ySoamnNhJ44',
+    type: 'NEW',
+  },
+  {
+    id: 2,
+    url: 'https://www.youtube.com/shorts/kn3fJqHgI-0',
+    type: 'MOTIVATION',
+  },
+  {
+    id: 3,
+    url: 'https://www.youtube.com/watch?v=ESXK4eeEWJI',
+    type: 'COGNITIVE_INTERVENTION',
+  },
+  {
+    id: 4,
+    url: 'https://youtu.be/HWDPdEDwBJ4',
+    type: 'COGNITIVE_INTERVENTION',
+  },
+  {
+    id: 5,
+    url: 'https://youtu.be/nMG3gc2A8Sg',
+    type: 'COGNITIVE_INTERVENTION',
+  },
+  {
+    id: 6,
+    url: 'https://youtu.be/iaXgae8mmJM',
+    type: 'COGNITIVE_INTERVENTION',
+  },
+  {
+    id: 7,
+    url: 'https://youtu.be/fp7q5JxEydU',
+    type: 'COGNITIVE_INTERVENTION',
+  },
+  {
+    id: 8,
+    url: 'https://www.youtube.com/shorts/bRhkYg4p28M',
+    type: 'DISTRACTION',
+  },
+  {
+    id: 9,
+    url: 'https://www.youtube.com/shorts/e9OAvHHhbGE',
+    type: 'DISTRACTION',
+  },
+  {
+    id: 10,
+    url: 'https://www.youtube.com/watch?v=3yBKS6LpI9o',
+    type: 'DISTRACTION',
+  },
+  {
+    id: 11,
+    url: 'https://www.youtube.com/watch?v=bg41b_l6NNM',
+    type: 'DISTRACTION',
+  },
+];

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -1,13 +1,26 @@
-import { useAppSelector } from '@/hooks';
+import { NavLink } from 'react-router-dom';
+
 import { Trigger } from '@/components';
+import { useAppSelector } from '@/hooks';
+import { requestUserData } from '@/services';
+import { getLocalDateString } from '@/utils';
 
 import { RootState } from '@/store';
 import * as S from './Home.styles';
 
 const Home = () => {
-  const { nickname } = useAppSelector((state: RootState) => state.user);
+  const { visitorId, nickname } = useAppSelector(
+    (state: RootState) => state.user
+  );
 
-  const handleClick = () => {};
+  const handleClick = () => {
+    const requestData = {
+      visitorId,
+      at: getLocalDateString(),
+    };
+
+    requestUserData('/button-click', requestData);
+  };
 
   return (
     <S.Container>
@@ -16,7 +29,9 @@ const Home = () => {
           {nickname}님 잘 오셨어요! 오늘 하루도 금연 화이팅 합시다!
         </S.Header>
       )}
-      <Trigger onClick={handleClick}>Press</Trigger>
+      <NavLink to="/video">
+        <Trigger onClick={handleClick}>Press</Trigger>
+      </NavLink>
       <S.Footer>담배가 땡긴다면 눌러보세요!</S.Footer>
     </S.Container>
   );

--- a/src/pages/Video/Video.styles.tsx
+++ b/src/pages/Video/Video.styles.tsx
@@ -1,3 +1,4 @@
+import { pxToRem } from '@/utils';
 import styled from 'styled-components';
 
 export const Container = styled.div`
@@ -7,4 +8,9 @@ export const Container = styled.div`
   align-items: center;
   width: 100%;
   height: 100vh;
+  padding-top: ${pxToRem(50)};
+
+  @media ${({ theme }) => theme.breakpoints.md} {
+    padding-top: ${pxToRem(63)};
+  }
 `;

--- a/src/pages/Video/Video.styles.tsx
+++ b/src/pages/Video/Video.styles.tsx
@@ -1,0 +1,10 @@
+import styled from 'styled-components';
+
+export const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  height: 100vh;
+`;

--- a/src/pages/Video/Video.tsx
+++ b/src/pages/Video/Video.tsx
@@ -1,0 +1,35 @@
+import { useNavigate } from 'react-router-dom';
+
+import { VideoPlayer } from '@/components';
+import { useAppSelector } from '@/hooks';
+import { requestUserData, findUserPreferedVideo } from '@/services';
+import { getLocalDateString } from '@/utils';
+
+import type { RootState } from '@/store';
+
+import * as S from './Video.styles';
+
+const Video = () => {
+  const navigate = useNavigate();
+  const user = useAppSelector((state: RootState) => state.user);
+  const video = findUserPreferedVideo(user);
+
+  const handleVideoEnded = () => {
+    const requestData = {
+      visitorId: user.visitorId,
+      contentsNumber: video.id,
+      nextImageOrVideoEndAt: getLocalDateString(),
+    };
+
+    requestUserData('/video-end', requestData);
+    navigate('/main');
+  };
+
+  return (
+    <S.Container>
+      <VideoPlayer url={video.url} onEnded={handleVideoEnded} />
+    </S.Container>
+  );
+};
+
+export default Video;

--- a/src/pages/Video/index.ts
+++ b/src/pages/Video/index.ts
@@ -1,0 +1,1 @@
+export { default as Video } from './Video';

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -1,1 +1,2 @@
 export { Home } from './Home';
+export { Video } from './Video';

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -4,13 +4,14 @@ import {
   Route,
 } from 'react-router-dom';
 
-import { Home } from '@/pages';
+import { Home, Video } from '@/pages';
 import { Layout } from '@/components';
 
 const router = createBrowserRouter(
   createRoutesFromElements(
     <Route element={<Layout />}>
       <Route path="/" element={<Home />} />
+      <Route path="/video" element={<Video />} />
     </Route>
   )
 );

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,3 +1,3 @@
 export { default as getImages } from './images';
-export { default as requestUserData } from './user';
+export { requestUserData, findUserPreferedVideo } from './user';
 export { default as initKakao } from './kakao';

--- a/src/services/user.ts
+++ b/src/services/user.ts
@@ -1,6 +1,10 @@
 import axios, { AxiosRequestConfig } from 'axios';
 
-import type { RequestData } from '@/types';
+import { VIDEOS } from '@/constants';
+import { getRandomNumberWithRange } from '@/utils';
+
+import type { User, RequestData } from '@/types';
+import type { Video, VideoType } from '@/constants/video';
 
 const axiosConfig: AxiosRequestConfig = {
   baseURL: import.meta.env.VITE_API_END_POINT,
@@ -8,7 +12,7 @@ const axiosConfig: AxiosRequestConfig = {
 
 const instance = axios.create(axiosConfig);
 
-const requestUserData = async (url: string, data: RequestData) => {
+export const requestUserData = async (url: string, data: RequestData) => {
   try {
     const response = await instance.post(url, data);
 
@@ -18,4 +22,17 @@ const requestUserData = async (url: string, data: RequestData) => {
   }
 };
 
-export default requestUserData;
+const getRandomVideo = (videos: Video[], videoType: VideoType) => {
+  const preferedVideos = videos.filter(({ type }) => type === videoType);
+  const index = getRandomNumberWithRange(0, preferedVideos.length - 1);
+
+  return preferedVideos[index];
+};
+
+export const findUserPreferedVideo = (user: User) => {
+  if (!user.preference) {
+    return getRandomVideo(VIDEOS, 'NEW');
+  }
+
+  return getRandomVideo(VIDEOS, user.preference);
+};

--- a/src/store/userSlice.ts
+++ b/src/store/userSlice.ts
@@ -1,19 +1,13 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
-import type { Preference, SmokingStatus } from '@/types';
-
-interface User {
-  visitorId: string;
-  nickname: string;
-  preference: Preference | null;
-  smokingStatus: SmokingStatus | null;
-}
+import type { User } from '@/types';
 
 const initialState: User = {
   visitorId: '',
   nickname: '',
   preference: null,
   smokingStatus: null,
+  seen: [],
 };
 
 const userSlice = createSlice({

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -22,4 +22,4 @@ export type {
   FormRequest,
   RequestData,
 } from './request';
-export type { Preference, SmokingStatus } from './user';
+export type { User, Preference, SmokingStatus } from './user';

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -7,3 +7,11 @@ export type SmokingStatus =
   | 'SMOKER_WITH_MOTIVATION'
   | 'SMOKER_WITHOUT_MOTIVATION'
   | 'NOT_SMOKER';
+
+export interface User {
+  visitorId: string;
+  nickname: string;
+  preference: Preference | null;
+  smokingStatus: SmokingStatus | null;
+  seen: number[];
+}


### PR DESCRIPTION
## 설명

영상을 보여주는 페이지를 구현했습니다. 

## 변경 사항

- User 타입 store에서 types로 이동
- User 타입에 본 영상에 대한 번호를 남길 배열 타입의 seen 프로퍼티 추가
- VideoPlayer의 이벤트 핸들러를 선택적으로 받을 수 있도록 수정
- Home에서 버튼 클릭 시 서버에 데이터를 보내고, video 페이지로 이동하도록 구현
- 유저가 보지 않은 비디오를 틀어주고, 끝나면 서버에 데이터를 보내고, main 페이지로 이동하도록 구현

## 스크린샷

<img width="447" alt="스크린샷 2023-03-24 오후 1 14 02" src="https://user-images.githubusercontent.com/68905615/227423122-0e9f3fea-3822-4a32-8059-f93e5df03ef4.png">
